### PR TITLE
Enable Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,11 @@
       <version>${httpcomponents.version}</version>
     </dependency>
     <dependency>
+      <groupId>xerces</groupId>
+      <artifactId>xercesImpl</artifactId>
+      <version>2.12.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
       <version>1.7.25</version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,8 @@
               <value>src/test/resources/logging.properties</value>
             </property>
           </systemProperties>
+          <!-- workaround for unexpected vm exit errors -->
+          <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
           <!-- 2 forks per cpu-core, don't reuse them (full isolation) -->
           <forkCount>2C</forkCount>
           <reuseForks>false</reuseForks>
+          <systemProperties>
+            <property>
+              <name>java.util.logging.config.file</name>
+              <value>src/test/resources/logging.properties</value>
+            </property>
+          </systemProperties>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/com/google/enterprise/secmgr/common/XmlUtil.java
+++ b/src/main/java/com/google/enterprise/secmgr/common/XmlUtil.java
@@ -16,7 +16,16 @@ package com.google.enterprise.secmgr.common;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.List;
+import javax.xml.XMLConstants;
+import javax.xml.namespace.QName;
+import org.apache.xerces.dom.DOMInputImpl;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Comment;
 import org.w3c.dom.DOMConfiguration;
@@ -33,17 +42,8 @@ import org.w3c.dom.ls.LSException;
 import org.w3c.dom.ls.LSInput;
 import org.w3c.dom.ls.LSOutput;
 import org.w3c.dom.ls.LSParser;
+import org.w3c.dom.ls.LSResourceResolver;
 import org.w3c.dom.ls.LSSerializer;
-
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.Reader;
-import java.io.StringWriter;
-import java.io.Writer;
-import java.util.List;
-
-import javax.xml.XMLConstants;
-import javax.xml.namespace.QName;
 
 /**
  * Utilities for manipulating XML files.
@@ -169,6 +169,16 @@ public class XmlUtil {
     LSInput lsInput = domImplLs.createLSInput();
     lsInput.setCharacterStream(input);
     LSParser parser = domImplLs.createLSParser(DOMImplementationLS.MODE_SYNCHRONOUS, null);
+    parser.getDomConfig().setParameter("resource-resolver", new LSResourceResolver(){
+      @Override
+      public LSInput resolveResource(
+          String type, String namespaceURI, String publicId, String systemId, String baseURI) {
+        // Explicitly disable external resource resolving
+        final LSInput input = new DOMInputImpl();
+        input.setByteStream(new ByteArrayInputStream("".getBytes()));
+        return input;
+      }
+    });
     try {
       return parser.parse(lsInput);
     } catch (LSException e) {

--- a/src/test/java/com/google/enterprise/secmgr/authncontroller/AuthnSessionManagerImplTest.java
+++ b/src/test/java/com/google/enterprise/secmgr/authncontroller/AuthnSessionManagerImplTest.java
@@ -25,6 +25,8 @@ import org.joda.time.DateTimeUtils;
  */
 public final class AuthnSessionManagerImplTest extends SecurityManagerTestCase {
 
+  private static final int EPSILON = 100;
+
   private static final long ONE_MINUTE = 60 * 1000;
 
   private static final long[] OFFSETS = new long[] { -ONE_MINUTE, -10, -1, 1, 10, ONE_MINUTE };
@@ -127,9 +129,9 @@ public final class AuthnSessionManagerImplTest extends SecurityManagerTestCase {
     AuthnSession session = AuthnSession.newInstance();
     String sessionId = session.getSessionId();
     manager.registerSession(session);
-    DateTimeUtils.setCurrentMillisOffset(sessionIdleTime - 10);
+    DateTimeUtils.setCurrentMillisOffset(sessionIdleTime - EPSILON);
     tryGetSession(true, sessionId, session);
-    DateTimeUtils.setCurrentMillisOffset(sessionIdleTime - 10 + sessionIdleTime + offset);
+    DateTimeUtils.setCurrentMillisOffset(sessionIdleTime - EPSILON + sessionIdleTime + offset);
     tryGetSession(offset <= 0, sessionId, session);
   }
 }

--- a/src/test/java/com/google/enterprise/secmgr/authncontroller/TrustManagerTest.java
+++ b/src/test/java/com/google/enterprise/secmgr/authncontroller/TrustManagerTest.java
@@ -140,7 +140,6 @@ public final class TrustManagerTest extends SecurityManagerTestCase {
 
     File tmpFile = File.createTempFile(getClass().getName() + "-trust", ".tmp");
     // ../testdata/trust.enterprise is copied from the file generated this way.
-    System.out.println(tmpFile.toString());
     manager.writeToFile(principals, tmpFile.getCanonicalPath());
     manager.setConfFile(tmpFile.getCanonicalPath());
     manager.load();

--- a/src/test/java/com/google/enterprise/secmgr/common/SecurePasswordHasherTest.java
+++ b/src/test/java/com/google/enterprise/secmgr/common/SecurePasswordHasherTest.java
@@ -91,7 +91,6 @@ public class SecurePasswordHasherTest extends TestCase {
 
   public void testMacInput() {
     String mac = SecurePasswordHasher.getMac(kUsername, kPassword);
-    System.out.println(mac);
 
     // Ensure mac function is deterministic (unlike fingerprint function)
     assertEquals(mac, SecurePasswordHasher.getMac(kUsername, kPassword));

--- a/src/test/java/com/google/enterprise/secmgr/common/XmlUtilTest.java
+++ b/src/test/java/com/google/enterprise/secmgr/common/XmlUtilTest.java
@@ -47,6 +47,21 @@ public class XmlUtilTest {
     assertEquals("hello, world", Files.asCharSource(tempFile, UTF_8).readFirstLine());
   }
 
+  /** Confirms that XML parsing is working. */
+  @Test
+  public void readXmlDocument() throws IOException {
+    String xml = "<?xml version=\"1.0\"?>"
+        + "<root xmlns=\"foo\" xmlns:xi=\"http://www.w3.org/2001/XInclude\">"
+        + "<element param=\"abcde\"><child param2=\"555\" param3=\"1234\">text"
+        + "</child></element><anotherElement>Content</anotherElement>"
+        + "</root>";
+
+    Document doc = XmlUtil.getInstance().readXmlDocument(new StringReader(xml));
+    assertNotNull(doc);
+    Element root = doc.getDocumentElement();
+    assertEquals("textContent", root.getTextContent());
+  }
+
   /** Confirms that XML external entities are not resolved. */
   @Test
   public void readXmlDocument_xxe() throws IOException {

--- a/src/test/java/com/google/enterprise/secmgr/http/HttpClientAdapterTest.java
+++ b/src/test/java/com/google/enterprise/secmgr/http/HttpClientAdapterTest.java
@@ -211,7 +211,7 @@ public class HttpClientAdapterTest extends SecurityManagerTestCase {
     // Count number of requests that completed "immediately":
     int nImmediate = 0;
     for (long delta : deltas) {
-      if (delta < 1500) {
+      if (delta < 2000) {
         nImmediate += 1;
       }
     }

--- a/src/test/java/com/google/enterprise/secmgr/modules/PolicyAclsModuleTest.java
+++ b/src/test/java/com/google/enterprise/secmgr/modules/PolicyAclsModuleTest.java
@@ -188,7 +188,8 @@ public class PolicyAclsModuleTest extends SecurityManagerTestCase {
         + "/" + "acl_urls_large.enterprise";
     String urls2Filename = FileUtil.getContextDirectory()
         + "/" + "acl_urls_2_large.enterprise";
-    runAuthorize(urlsFilename, urls2Filename, 100000);
+    // TODO: detect file read completion instead of sleeping for a definite amount of time
+    runAuthorize(urlsFilename, urls2Filename, 120000);
   }
 
   private void runAuthorize(String urlsFilename, String urls2Filename,

--- a/src/test/java/com/google/enterprise/secmgr/saml/MetadataEditorTest.java
+++ b/src/test/java/com/google/enterprise/secmgr/saml/MetadataEditorTest.java
@@ -56,11 +56,9 @@ public class MetadataEditorTest extends SecurityManagerTestCase {
     MetadataEditor.writeMetadataDocument(base, fileWriter);
     fileWriter.close();
     filecontents = slurpFile(file);
-    // System.out.println(filecontents);
     clientCert
         = MetadataEditor.normalizeCertificate(
             slurpFile(FileUtil.getContextFile("saml-client-test.crt")));
-    // System.out.println(clientCert);
   }
 
   public void testGetClients() throws Exception {
@@ -112,7 +110,6 @@ public class MetadataEditorTest extends SecurityManagerTestCase {
     SamlClientIdp client1 = makeClient(URL2, clientCert);
     List<SamlClientIdp> clients = ImmutableList.of(client0, client1);
     String contents = MetadataEditor.setSamlClientsInMetadata(filecontents, clients);
-    // System.out.println(contents);
 
     // Parse the document and extract the clients.
     Document document = MetadataEditor.stringToMetadataDocument(contents);

--- a/src/test/java/com/google/enterprise/secmgr/servlets/SamlArtifactResolveTest.java
+++ b/src/test/java/com/google/enterprise/secmgr/servlets/SamlArtifactResolveTest.java
@@ -88,7 +88,6 @@ public class SamlArtifactResolveTest extends SecurityManagerTestCase {
     samlArtifactResolveInstance.doPost(mockRequest, mockResponse);
 
     String returnedContent = mockResponse.getContentAsString();
-    System.out.println("content: \n" + returnedContent);
 
     /** make sure we got something back */
     assertTrue(!returnedContent.isEmpty());

--- a/src/test/java/com/google/enterprise/secmgr/testing/SecurityManagerTestCase.java
+++ b/src/test/java/com/google/enterprise/secmgr/testing/SecurityManagerTestCase.java
@@ -36,6 +36,7 @@ import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestResult;
 import junit.framework.TestSuite;
+import junit.textui.ResultPrinter;
 import junit.textui.TestRunner;
 import org.easymock.EasyMockSupport;
 import org.joda.time.DateTimeUtils;
@@ -168,10 +169,24 @@ public class SecurityManagerTestCase extends TearDownTestCase {
    * @throws AssertionFailedError if the test had one or more failures.
    */
   public static void runTestCase(Test test) {
-    TestRunner runner = (new TestRunner(getPrintStream()));
+    TestRunner runner = new TestRunner(new SecurityManagerTestResultPrinter(getPrintStream()));
     TestResult result = runner.doRun(test);
     if (!result.wasSuccessful()) {
       throw new AssertionFailedError("Nested test had failures.");
+    }
+  }
+
+  private static class SecurityManagerTestResultPrinter extends ResultPrinter {
+
+    public SecurityManagerTestResultPrinter(PrintStream writer) {
+      super(writer);
+    }
+
+    /*
+     * Overriding this method to prevent jUnit of flooding the console with dots
+     */
+    @Override
+    public void startTest(Test test) {
     }
   }
 

--- a/src/test/resources/logging.properties
+++ b/src/test/resources/logging.properties
@@ -1,9 +1,9 @@
 handlers = java.util.logging.ConsoleHandler
 
 # Default global logging level.
-.level = INFO
+.level = OFF
 
 # Use our own formatter for console output.
-java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.level = OFF
 java.util.logging.ConsoleHandler.formatter = com.google.enterprise.secmgr.common.LogFormatter
 java.util.logging.ConsoleHandler.encoding = UTF-8


### PR DESCRIPTION
Prepare for Travis CI:
- enable Travis builds (needs repository setup) - fixes #12 
- fix outer environment test failure (XEE protection was applied in Google JDK) - fixes #15 
- fix flaky test failures (timed tests w/ tight epsilons) - fixes #16 
- reduce console test logging (to fit Travis max log size limit) - fixes #13 